### PR TITLE
add variable netq_repo_version and netq_repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Cumulus Linux 3.x
 ## Role Variables
 
 * `netq_backend_server`: IP of the netq server
+* `netq_repo_version`: Version of the netq repo, e.g. "netq-1.4"
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Cumulus Linux 3.x
 
 None
 
+## Notes
+
+This role will not handle the removal or existing repo entries in the event
+you are changing the repo version. This is left to the user. You could
+simply change "state: present" to "state: absent" for you previous
+version before updating to the new version.  
+
+
 ## Example Playbook
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+# defaul to "latest" unless overridden
+netq_repo_version: netq-latest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Add netq repo
   apt_repository:
-    repo: deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 netq-latest
+    repo: deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 {{ netq_repo }}
     state: present
 
 # The netq package installs addtional config to rsyslog

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,3 +4,5 @@ netq_backend_config:
     port: 6379
     role: master
     server: "{{ netq_backend_server|mandatory }}"
+
+netq_repo: "{{ netq_repo_version }}"


### PR DESCRIPTION
to allow explicit configuration of netq repo version...

One issue I am not able to account for yet, is removing the old repo version that might be in the sources file...  the apt_repository repo module only adds or removes specific entries...  should we clobber the whole file? I am not sure what's best here.  Any suggestions?
