### PR TITLE
test filter fix

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Check Cumulus version
   fail:
     msg: "NetQ is only supported on Cumulus versions 3.3 and later"
-  when: ansible_lsb.release | version_compare('3.3', '<')
+  when: when: ansible_lsb.release is version_compare('3.3', '<')
 
 - name: Add netq repo
   apt_repository:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,9 +12,9 @@
 
 # The netq package installs addtional config to rsyslog
 - name: Install netq agent
-  apt:
+  package:
     name: cumulus-netq
-    update_cache: yes
+    state: present
   notify: restart rsyslog
 
 - name: Configure netq agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Check Cumulus version
   fail:
     msg: "NetQ is only supported on Cumulus versions 3.3 and later"
-  when: when: ansible_lsb.release is version_compare('3.3', '<')
+  when: ansible_lsb.release is version_compare('3.3', '<')
 
 - name: Add netq repo
   apt_repository:


### PR DESCRIPTION
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of 
using result|version_compare use result is version_compare.
This feature will be removed in version 2.9. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.

The syntax I am using here seems to work in 2.4.4.0 through 2.8.0, assuming its working as intended. Please review. 