### PR TITLE
IG-8579: Change NetQ config to show link up messages

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,5 +4,8 @@ netq_backend_config:
     port: 6379
     role: master
     server: "{{ netq_backend_server|mandatory }}"
+# IG-8579: Enable link recovery messages
+  link:
+    enable: true
 
 netq_repo: "{{ netq_repo_version }}"


### PR DESCRIPTION
I've updated the NetQ configuration step in this shared role to notify us when the links go up (hopefully).  This role is used during the deploy.switches play.