### PR TITLE
Netq3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ansible-netq-agent
 
-Install NetQ agent on Cumulus Linux switches
+A role for Installing NetQ3 agents on Cumulus Linux switches.
 
 For more information, see the [NetQ documentation](https://docs.cumulusnetworks.com/display/NETQ/).
 
@@ -21,10 +21,10 @@ None
 ## Notes
 
 This role will handle the removal of existing 1.4 and 2.4 repo entries in the event
-you are changing the repo version from an earlier version. If the current version is 
+you are changing the repo version from an earlier version. If the current version is
 something other than 1.4 or 2.4 (like netq-latest) this is left to the user. You could
 simply change "state: present" to "state: absent" for your previous
-version before updating to the new version or add the desired version 
+version before updating to the new version or add the desired version
 to be removed in the task: "Remove any old netq repos" in /task/main.yml
 
 If the versions 1.4 or 2.4 are already installed they will be upgraded to 3.0

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ None
 This role will handle the removal of existing 1.4 and 2.4 repo entries in the event
 you are changing the repo version from an earlier version. If the current version is 
 something other than 1.4 or 2.4 (like netq-latest) this is left to the user. You could
-simply change "state: present" to "state: absent" for you previous
-version before updating to the new version.  
+simply change "state: present" to "state: absent" for your previous
+version before updating to the new version or add the desired version 
+to be removed in the task: "Remove any old netq repos" in /task/main.yml
 
 If the versions 1.4 or 2.4 are already installed they will be upgraded to 3.0
 or latest depending on `netq_repo_version`. If the Cumulus Linux host has no

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # ansible-netq-agent
 
-Install NetQ agent on Cumulus switches
+Install NetQ agent on Cumulus Linux switches
 
 For more information, see the [NetQ documentation](https://docs.cumulusnetworks.com/display/NETQ/).
 
 ## Requirements
 
-Cumulus Linux 3.x
+Cumulus Linux => 3.3
+Cumulus NetQ => 3.x
 
 ## Role Variables
 
 * `netq_backend_server`: IP of the netq server
-* `netq_repo_version`: Version of the netq repo, e.g. "netq-1.4"
+* `netq_repo_version`: Version of the netq repo, e.g. "netq-3.0" or "netq-latest"
 
 ## Dependencies
 
@@ -19,11 +20,18 @@ None
 
 ## Notes
 
-This role will not handle the removal or existing repo entries in the event
-you are changing the repo version. This is left to the user. You could
+This role will handle the removal of existing 1.4 and 2.4 repo entries in the event
+you are changing the repo version from an earlier version. If the current version is 
+something other than 1.4 or 2.4 (like netq-latest) this is left to the user. You could
 simply change "state: present" to "state: absent" for you previous
 version before updating to the new version.  
 
+If the versions 1.4 or 2.4 are already installed they will be upgraded to 3.0
+or latest depending on `netq_repo_version`. If the Cumulus Linux host has no
+agents already installed, then netq-agent and netq-apps (cli)
+version 3.0 or latest will be installed.
+
+This role currently doesn't consider Ubuntu or RHE/CentOS hosts, only Cumulus Linux.
 
 ## Example Playbook
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
         - 3.3
         - 3.4
         - 3.5
+        - 3.7
   galaxy_tags:
     - networking
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,14 @@
     msg: "NetQ is only supported on Cumulus versions 3.3 and later"
   when: ansible_lsb.release | version_compare('3.3', '<')
 
+- name: Remove any old netq repos
+  apt_repository:
+    repo: deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 {{ item }} 
+    state: absent
+  with_items:
+    - 'netq-1.4'
+    - 'netq-2.4'
+
 - name: Add netq repo
   apt_repository:
     repo: deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 {{ netq_repo }}
@@ -13,12 +21,15 @@
 # The netq package installs addtional config to rsyslog
 - name: Install netq agent
   apt:
-    name: cumulus-netq
+    name: {{ item }}
     update_cache: yes
   notify: restart rsyslog
+  with_items:
+    - 'netq-agent' 
+    - 'netq-apps3'
 
 - name: Configure netq agent
   copy:
     content: "{{ netq_backend_config|to_nice_yaml }}"
-    dest: /etc/netq/config.d/backend_server.yml
+    dest: /etc/netq/config.d/netq.yml
   notify: restart netq

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
   apt:
     name: ['netq-agent', 'netq-apps']
     update_cache: yes
+    state: latest
   notify: restart rsyslog
 
 - name: Configure netq agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,12 +21,9 @@
 # The netq package installs addtional config to rsyslog
 - name: Install netq agent
   apt:
-    name: "{{ item }}"
+    name: ['netq-agent', 'netq-apps']
     update_cache: yes
   notify: restart rsyslog
-  with_items:
-    - 'netq-agent' 
-    - 'netq-apps'
 
 - name: Configure netq agent
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,11 +3,11 @@
 - name: Check Cumulus version
   fail:
     msg: "NetQ is only supported on Cumulus versions 3.3 and later"
-  when: ansible_lsb.release | version_compare('3.3', '<')
+  when: ansible_lsb.release is version_compare('3.3', '<')
 
 - name: Remove any old netq repos
   apt_repository:
-    repo: deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 {{ item }} 
+    repo: deb http://apps3.cumulusnetworks.com/repos/deb CumulusLinux-3 {{ item }}
     state: absent
   with_items:
     - 'netq-1.4'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,12 +21,12 @@
 # The netq package installs addtional config to rsyslog
 - name: Install netq agent
   apt:
-    name: {{ item }}
+    name: "{{ item }}"
     update_cache: yes
   notify: restart rsyslog
   with_items:
     - 'netq-agent' 
-    - 'netq-apps3'
+    - 'netq-apps'
 
 - name: Configure netq agent
   copy:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,13 @@
 ---
+
 netq_backend_config:
-  backend:
-    port: 6379
-    role: master
+  netq-agent:
+    port: 31980
+    server: "{{ netq_backend_server|mandatory }}"
+    vrf: default
+  netq-cli:
+    netq-user: admin
+    port: 32708
     server: "{{ netq_backend_server|mandatory }}"
 
 netq_repo: "{{ netq_repo_version }}"


### PR DESCRIPTION
Updating the role to work exclusively with NetQ 3. Should we tag/release on master to mark the history where NetQ 1.4 would still be workable?