### PR TITLE
IG-9093 adding 3.1 to remove old netq repos task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
     - 'netq-1.4'
     - 'netq-2.4'
     - 'netq-3.0'
+    - 'netq-3.1'
 
 - name: Add netq repo
   apt_repository:


### PR DESCRIPTION
Netq 3.3.0 is out, adding the previous version to the "Remove any old netq repos" task.